### PR TITLE
edit .yarnrc.yml

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,3 +4,7 @@ plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
     spec: "@yarnpkg/plugin-workspace-tools"
 nodeLinker: node-modules
+yarnPath: .yarn/releases/yarn-3.0.2.cjs
+progressBarStyle: "jack"
+enableColors : true
+enableHyperlinks : true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suke",
-  "packageManager": "yarn@3.0.0",
+  "packageManager": "yarn@3.0.2",
   "private": true,
   "scripts": {
     "prepack": "yarn workspaces foreach run yarn clean && yarn compile",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20138,11 +20138,11 @@ typescript@^4.4.3:
 
 "typescript@patch:typescript@^4.4.3#~builtin<compat/typescript>":
   version: 4.4.3
-  resolution: "typescript@patch:typescript@npm%3A4.4.3#~builtin<compat/typescript>::version=4.4.3&hash=d8b4e7"
+  resolution: "typescript@patch:typescript@npm%3A4.4.3#~builtin<compat/typescript>::version=4.4.3&hash=32657b"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 215a59742afb7e0c3668e2c50ca19813deb24b3cc0d16ac3591990e033728050aaa99e159a72b54cb43653f16c778a5cf9dfeed1f51c3b105710ae082c064af7
+  checksum: 28ab98313afab46788ff41014fdb5932430ada6e03cf9e92ac47f406526a2cac1ae2894834e7da61e46b7429318e9c47f45ba8de323332f0cb9af99b72ebae74
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The `yarnPath` property in the `.yarnrc.yml` was missing in the main branch. It would make it difficult for our team to determine which version of the Yarn Package manager is preferred when installing for this project.

I changed the package manager version to `3.0.2`.
Added the other properties just for fun.